### PR TITLE
Quickfix to resolve wrong reply "Sorry, I'm unable to reach X" /fix #…

### DIFF
--- a/functions/openhab.js
+++ b/functions/openhab.js
@@ -310,7 +310,11 @@ function turnOnOff(request, response, i, j) {
 					payload: {
 						commands: {
 							ids: [ deviceId ],
-							status: "SUCCESS"
+							status: "SUCCESS",
+                           				states: {
+          							on: params.on,
+          							online: true
+        						}
 						}
 					}
 			}


### PR DESCRIPTION
…44 (#114)

* Bugfix: Sends the correct shutters commands to OpenHab
The process intent "action.devices.DISCONNECT" implemented

Signed-off-by: Sascha Reinshagen <reinshagen@posteo.de>

* Quickfix to resolve wrong reply "Sorry, I'm unable to reach X" /fix #44

https://developers.google.com/assistant/smarthome/traits/onoff#device-commands

Signed-off-by: Sascha Reinshagen <reinshagen@posteo.de>